### PR TITLE
Introduce a new DependencyCheck workflow for multi-module projects

### DIFF
--- a/.github/workflows/sca_multimodule_bt.yml
+++ b/.github/workflows/sca_multimodule_bt.yml
@@ -1,0 +1,95 @@
+name: SCA - Dependency Check for Multi-module Projects (BT)
+on:
+  workflow_call:
+    secrets:
+      NVD_API_KEY:
+        required: false
+      DOJO_TOKEN: 
+        required: false
+      DOJO_URL: 
+        required: false
+
+jobs:
+   SCA:
+    name: SCA - Dependency Check Analysis (BT)
+    #if: false
+    runs-on:  ubuntu-latest
+    steps:
+
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Cache Dependency-Check Data
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/dependency-check-data
+          key: ${{ runner.os }}-dependency-check-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-dependency-check
+
+      - name: Write Dependency-Check Properties
+        run: |
+          mkdir -p .dependency-check
+          echo "nvd.api.delay=3500" > .dependency-check/dependency-check.properties
+          
+      - name: Build with Gradle Wrapper & Run Dependency-Check
+        continue-on-error: true
+        id: depcheck
+        run: |
+          set +e
+          ./gradlew dependencyCheckAggregate --info
+          exit_code=$?
+          echo "exit_code=$exit_code" >> $GITHUB_ENV
+          echo "::set-output name=exit_code::$exit_code"  # Set the exit code as output for subsequent steps
+          if [[ $exit_code -ne 0 ]]; then
+            echo "Dependency Check failed with code $exit_code — marking as neutral."
+            exit 78
+          fi
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          dependencyCheck.properties: .dependency-check/dependency-check.properties
+
+      - name: Find DC_HTML_REPORT
+        if: steps.depcheck.outputs.exit_code == '0'
+        run: |
+           DC_HTML_REPORT=$(find . -type f -name "*dependency-check-report.html")
+           echo "DC_HTML_REPORT=$DC_HTML_REPORT" >> $GITHUB_ENV
+           
+      - name: Upload results - SCA
+        if: steps.depcheck.outputs.exit_code == '0'
+        uses: actions/upload-artifact@master
+        with:
+           name: Dependency Check Report
+           path: ${{ env.DC_HTML_REPORT }}
+
+      # Posts the result of the scan to DefectDojo
+      - name: Send report to DefectDojo
+        if: (steps.depcheck.outputs.exit_code == '0') && (github.repository_owner == 'eu-digital-identity-wallet' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
+        run: |
+          export "DC_XML_REPORT=$(find . -type f -name "*dependency-check-report.xml")"
+          if [[ -z "$DC_XML_REPORT" ]]; then exit 0; fi
+          export "SCAN_DATE=$(TZ='EET' date '+%Y-%m-%d')"
+          curl -X POST "$DOJO_URL/api/v2/reimport-scan/" \
+                            -H "Authorization: Token $DOJO_TOKEN" \
+                            -F "active=true" \
+                            -F "scan_type=Dependency Check Scan" \
+                            -F "minimum_severity=Info" \
+                            -F "skip_duplicates=true" \
+                            -F "close_old_findings=true" \
+                            -F "file=@$DC_XML_REPORT" \
+                            -F "scan_date=$SCAN_DATE" \
+                            -F "auto_create_context=True" \
+                            -F "product_name=${{ github.repository }}-${{ github.ref_name }}" \
+                            -F "engagement_name=Software Composition Analysis - ${{ github.repository }}-${{ github.ref_name }}"
+        env:
+         DOJO_TOKEN: ${{ secrets.DOJO_TOKEN }}
+         DOJO_URL: ${{ secrets.DOJO_URL }}


### PR DESCRIPTION
This PR introduces a new workflow for running DependencyCheck on multi-module projects.

The workflow is a copy of `sca_bt.yml`, but instead of calling `./gradlew dependencyCheckAnalyze`, we instead call `./gradlew dependencyCheckAggrate`.

This creates a single aggregate report that contains findings for all sub-modules of the multi-module project.